### PR TITLE
Fix bug in default value for optimiser_args

### DIFF
--- a/main_vqe.py
+++ b/main_vqe.py
@@ -145,7 +145,7 @@ def rotosolver(ansatz_func, hamiltonian, thetas, depth):
     return thetas
 
 def vqe(molecule, ansatz_func, num_iter, depth, optimiser_func, 
-        optimiser_args={'optimiser_args': None}, print_all=False, plot_vqe=False):
+        optimiser_args={}, print_all=False, plot_vqe=False):
     """Run the Variational Quantum Eigensolver (VQE) for a specified number of iteration given 
        an ansatz and an optimiser. 
 


### PR DESCRIPTION
We want to pass an empty dictionary which gets unpacked to no arguments, if the algorithm takes no parameters. The previous code passed the named argument optimiser_args = None, which rotosolve did not accept.

NB: This is not my submission, just a bugfix.